### PR TITLE
Don't Escape Wiki domain update

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -429,11 +429,6 @@
         "official": true
     },
     {
-        "id": "dontescape",
-        "oldId": "dont-escape",
-        "name": "Don't Escape"
-    },
-    {
         "id": "dragoncourt",
         "name": "Dragon Court"
     },
@@ -1149,6 +1144,11 @@
         "id": "satisfactory",
         "name": "Satisfactory",
         "official": true
+    },
+    {
+        "id": "scriptwelder",
+        "oldId": "dont-escape",
+        "name": "Scriptwelder"
     },
     {
         "id": "seaofthieves",


### PR DESCRIPTION
The Wiki URL for the Don't Escape Wiki was changed/renamed. I think this edit is sufficient, otherwise let me know if not, thanks.