### PR TITLE
Add Disco Elysium to sites.json

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -761,6 +761,10 @@
 		"name": "Divinity: Original Sin"
 	},
 	{
+		"id": "discoelysium",
+		"name": "Disco Elysium"
+	},
+	{
 		"id": "disfigure",
 		"name": "Disfigure"
 	},


### PR DESCRIPTION
I've noticed Disco Elysium is on Fandom and wiki.gg, though I'm unsure about their history.